### PR TITLE
feat: Add streak.py and related tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,28 @@
+name: Run Pytest
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+
+    - name: Run tests
+      run: |
+        PYTHONPATH=. pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,128 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/streak.py
+++ b/streak.py
@@ -1,0 +1,20 @@
+def longest_positive_streak(nums: list[int]) -> int:
+    """
+    Calculates the length of the longest consecutive run of positive integers.
+
+    Args:
+        nums: A list of integers.
+
+    Returns:
+        The length of the longest streak of positive numbers.
+    """
+    max_streak = 0
+    current_streak = 0
+    for num in nums:
+        if num > 0:
+            current_streak += 1
+        else:
+            max_streak = max(max_streak, current_streak)
+            current_streak = 0
+    max_streak = max(max_streak, current_streak)
+    return max_streak

--- a/tests/test_streak.py
+++ b/tests/test_streak.py
@@ -1,0 +1,41 @@
+import pytest
+from streak import longest_positive_streak
+
+def test_empty_list():
+    """Test that an empty list returns a streak of 0."""
+    assert longest_positive_streak([]) == 0
+
+def test_all_positive():
+    """Test a simple case with all positive numbers."""
+    assert longest_positive_streak([1, 2, 3, 4, 5]) == 5
+
+def test_with_negatives():
+    """Test that negative numbers correctly break the streak."""
+    assert longest_positive_streak([1, 2, -1, 3, 4]) == 2
+
+def test_with_zeros():
+    """Test that zeros correctly break the streak."""
+    assert longest_positive_streak([1, 2, 0, 3, 4, 5]) == 3
+
+def test_multiple_streaks():
+    """Test that the function returns the longest of multiple streaks."""
+    assert longest_positive_streak([1, 0, 2, 2, 0, 3, 3, 3]) == 3
+    assert longest_positive_streak([1, 1, 1, 0, 2, 2, 0, 1]) == 3
+
+def test_no_positive_numbers():
+    """Test a list with no positive numbers."""
+    assert longest_positive_streak([-1, -5, 0]) == 0
+
+def test_single_element_list():
+    """Test lists with a single element."""
+    assert longest_positive_streak([1]) == 1
+    assert longest_positive_streak([-1]) == 0
+    assert longest_positive_streak([0]) == 0
+
+def test_example_from_prompt():
+    """Test the specific example from the problem description."""
+    assert longest_positive_streak([2, 3, -1, 5, 6, 7, 0, 4]) == 3
+
+def test_streak_at_end():
+    """Test when the longest streak is at the end of the list."""
+    assert longest_positive_streak([1, 2, 0, 4, 5, 6, 7]) == 4


### PR DESCRIPTION
- Implements `longest_positive_streak` to find the longest run of positive integers.
- Adds a comprehensive pytest suite in `tests/test_streak.py`.
- Sets up a GitHub Actions workflow (`.github/workflows/pytest.yml`) to run tests automatically on push and pull_request.
- Includes a `.gitignore` file to exclude common Python artifacts.